### PR TITLE
* Allow overriding of argument with 'undef'(null)

### DIFF
--- a/lib/PGObject/Simple/Role.pm
+++ b/lib/PGObject/Simple/Role.pm
@@ -232,7 +232,7 @@ sub call_dbmethod {
         $argname =~ s/^in_//;
         local $@;
         eval { $db_arg = $self->can($argname)->($self) } if ref $self and $argname;
-        $db_arg = $args{args}->{$argname} if $args{args}->{$argname};
+        $db_arg = $args{args}->{$argname} if exists $args{args}->{$argname};
         $db_arg = $db_arg->to_db if eval {$db_arg->can('to_db')};
         $db_arg = { type => 'bytea', value => $db_arg} if $_->{type} eq 'bytea';
 


### PR DESCRIPTION
Required to make template printing work in LedgerSMB 1.5.