### PR TITLE
fixes for _DBH in constructor

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for PGObject-Simple-Role
 
+2.0.2	2017-05-20
+	Fixing backwards compatibility issue with _DBH in constructor
+
 2.0.1	2017-05-20
 	Fixing an issue where package accessors do not provide package defaults
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for PGObject-Simple-Role
 
+2.0.1	2017-05-20
+	Fixing an issue where package accessors do not provide package defaults
+
 2.0	2017-05-19
 	Depending now on PGObject::Simple 3
 	No more code duplication

--- a/lib/PGObject/Simple/Role.pm
+++ b/lib/PGObject/Simple/Role.pm
@@ -13,11 +13,11 @@ PGObject::Simple::Role - Moo/Moose mappers for minimalist PGObject framework
 
 =head1 VERSION
 
-Version 2
+Version 2.0.1
 
 =cut
 
-our $VERSION = 2.000000;
+our $VERSION = 2.000001;
 
 =head1 SYNOPSIS
 
@@ -133,7 +133,8 @@ stored prcedures to an object class.
 =cut
 
 sub _build__funcprefix {
-    return $_[0]->_get_prefix;
+    my ($self)  = @_;
+    return $self->_get_prefix;
 }
 
 sub _get_prefix {
@@ -164,7 +165,8 @@ Returns the schema bound to the object
 
 sub funcschema {
     my ($self)  = @_;
-    return $self->_funcschema;
+    return $self->_funcschema if ref $self;
+    return "$self"->_get_schema();
 }
 
 =head2 funcprefix
@@ -175,7 +177,9 @@ Prefix for functions
 
 sub funcprefix {
     my ($self) = @_;
-    return $self->_funcprefix;
+    
+    return $self->_funcprefix if ref $self;
+    return "$self"->_get_prefix();
 }
 
 =head1 REMOVED METHODS

--- a/lib/PGObject/Simple/Role.pm
+++ b/lib/PGObject/Simple/Role.pm
@@ -13,11 +13,11 @@ PGObject::Simple::Role - Moo/Moose mappers for minimalist PGObject framework
 
 =head1 VERSION
 
-Version 2.0.1
+Version 2.0.2
 
 =cut
 
-our $VERSION = 2.000001;
+our $VERSION = 2.000002;
 
 =head1 SYNOPSIS
 
@@ -79,9 +79,25 @@ has _dbh => (  # use dbh() to get and set_dbh() to set
        },
 );
 
+has _DBH => ( # backwards compatible for 1.x. 
+	is => 'lazy',
+       isa => sub { 
+                    warn 'deprecated _DBH used.  rename to _dbh when you can';
+                    croak "Expected a database handle.  Got $_[0] instead"
+                       unless eval {$_[0]->isa('DBI::db')};
+       },
+);
+
 sub _build__dbh {
     my ($self) = @_;
+    return $self->{_DBH} if $self->{_DBH};
     return $self->_get_dbh;
+}
+
+sub _build__DBH {
+    my ($self) = @_;
+    return $self->{_dbh} if $self->{_dbh};
+    return $self->_dbh;
 }
 
 sub _get_dbh {

--- a/t/01-basic-constructor.t
+++ b/t/01-basic-constructor.t
@@ -19,11 +19,13 @@ sub _get_dbh {
     return 1;
 }
 
+sub _get_prefix { 'foo' };
+
 ##########
 
 package main;
 
-use Test::More tests => 12;
+use Test::More tests => 14;
 use Test::Exception;
 use DBI;
 
@@ -40,6 +42,7 @@ my $obj;
 lives_ok {$obj = test1->new(%args)} 'created new object without crashing';
 ok(eval {$obj->isa('test1')}, 'ISA test passed');
 is($obj->id, 3, 'attribute id passed');
+is($obj->funcprefix, '', 'Got correct function prefix(empty)');
 is($obj->_registry, undef, 'Undefined registry at first');
 is($obj->foo, 'test1', 'attribute foo passed');
 is($obj->bar, 'test2', 'attribute bar passed');
@@ -49,6 +52,7 @@ throws_ok {$obj->_build__dbh(1)} qr/Subclasses MUST set/,
           'Threw exception, "Subclasses MUST set"';
 
 lives_ok {$obj = test2->new(%args)} 'created new object without crashing';
+is($obj->funcprefix, 'foo', 'Got correct function prefix');
 throws_ok {$obj->_dbh} qr/Expected a database handle/, 
           'Threw exception, "Expected a database handle"';
 lives_ok {$obj->set_dbh(4) } 'set-dbh goes through isa check';

--- a/t/02-dbtests.t
+++ b/t/02-dbtests.t
@@ -149,15 +149,15 @@ is($result->{foobar}, 26, 'Correct result, argument overrides');
 
 throws_ok{$obj->call_dbmethod(funcname => 'bar', dbh => $dbh1)} qr/No such function/, 'No such function thrown using wrong db';
 
-dies_ok { $obj = test3->new()->_dbh }, 'test3 has a bad _get_dbh function, dies by default';
+dies_ok { test3->new()->_dbh } 'test3 has a bad _get_dbh function, dies by default';
 
-dies_ok { $obj = test3->new()->dbh }, 'test3 has a bad _get_dbh function, dies by default getting dbh';
+dies_ok { test3->new()->dbh } 'test3 has a bad _get_dbh function, dies by default getting dbh';
 
-lives_ok { $obj = test3->new(_DBH => $dbh) }, 'test3 has a bad _get_dbh function, but can set dbh via _DBH';
+lives_ok { $obj = test3->new(_DBH => $dbh) } 'test3 has a bad _get_dbh function, but can set dbh via _DBH';
 
 is($obj->dbh, $dbh, 'Got correct dbh back from _DBH');
 
-lives_ok { $obj = test3->new(_dbh => $dbh) }, 'test3 has a bad _get_dbh function, but can set via _dbh';
+lives_ok { $obj = test3->new(_dbh => $dbh) } 'test3 has a bad _get_dbh function, but can set via _dbh';
 
 is($obj->dbh, $dbh, 'Got correct dbh back from _dbh');
 # Teardown connections


### PR DESCRIPTION
for the future, _DBH has been changed to _dbh for consistency reasons.  This adds backwards-compatibility handling for now with the idea we can simplify in the future.